### PR TITLE
[Feature] Add links to projects

### DIFF
--- a/web/components/projectCard.tsx
+++ b/web/components/projectCard.tsx
@@ -1,5 +1,7 @@
 import styled from "styled-components";
 import {
+  Black,
+  FullyTransparent,
   HalfShadow,
   LightText,
   ModeratelyDarken,
@@ -44,6 +46,14 @@ export const ProjectCardHeading = styled.h2`
   padding: 10px 0 5px 0;
   max-width: 500px;
   font-weight: 700;
+  a {
+    color: ${LightText};
+    text-decoration-color: ${LightText};
+  }
+  a:where(:hover, :focus-visible) {
+    color: ${Black};
+    text-decoration-color: ${FullyTransparent};
+  }
 `;
 
 export const ProjectCardBody = styled.p`
@@ -78,7 +88,10 @@ export const ProjectCard = ({ project }: ProjectCardProps) => (
   <ProjectCardWrapper>
     <ProjectCardAccentWrapper />
     <ProjectCardTextWrapper>
-      <ProjectCardHeading>{project.name}</ProjectCardHeading>
+      <ProjectCardHeading>
+        {!!project.url && <a href={project.url}>{project.name}</a>}
+        {!project.url && project.name}
+      </ProjectCardHeading>
       <ProjectCardBody>{project.description}</ProjectCardBody>
     </ProjectCardTextWrapper>
   </ProjectCardWrapper>

--- a/web/data/projects.yaml
+++ b/web/data/projects.yaml
@@ -1,6 +1,6 @@
 - name: Clark
   displayOnPage: true
-  url: https://github.com/renderos17/Clark
+  url: https://github.com/renderos17/Clark#clark-cad
   code: https://github.com/renderos17/ClarkCode
   cad: https://github.com/renderos17/Clark
   description: 60-pound custom designed and fabricated autonomous robot utilizing sensor fusion and computer vision with a convolutional neural network.
@@ -31,7 +31,7 @@
 
 - name: 7Words
   displayOnPage: true
-  url: https://github.com/renderos17/7Words
+  url: https://github.com/renderos17/7Words#7words
   code: https://github.com/renderos17/7Words
   description: Python tool used to check song lyrics in playlists for potentially explicit language using the Genius and Spotify APIs. Designed for radio stations.
   used:


### PR DESCRIPTION
White with matching underline since the default yellow style was a bit too much visually.

<img width="820" alt="Screen Shot 2022-05-16 at 7 36 29 AM" src="https://user-images.githubusercontent.com/16907897/168617897-6ae67387-e85b-48c2-a37a-bc5ef2bbf4ed.png">
